### PR TITLE
Automatic naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,8 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Between old migrations, differs between different copies of the database
+# To remove from local git:
+# git rm --cached 0a43986f4f83_remove_selected_tabs_column_from_event.py
+migrations/versions/0a43986f4f83_remove_selected_tabs_column_from_event.py

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ import socket
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import UniqueConstraint, CheckConstraint, event
+from sqlalchemy import UniqueConstraint, CheckConstraint, MetaData, event
 from sqlalchemy.engine import Engine
 
 # Initialize Flask app
@@ -24,8 +24,15 @@ app.config['SECRET_KEY'] = os.urandom(24).hex() #protects user sessions
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///shindig.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
+metadata_obj = MetaData(naming_convention={
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+})
 # Initialize database
-db = SQLAlchemy(app)
+db = SQLAlchemy(app, metadata=metadata_obj)
 migrate = Migrate(app, db)
 socketio = SocketIO(app, async_mode='threading')
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -19,7 +19,7 @@ def get_engine():
     try:
         # this works with Flask-SQLAlchemy<3 and Alchemical
         return current_app.extensions['migrate'].db.get_engine()
-    except TypeError:
+    except (TypeError, AttributeError):
         # this works with Flask-SQLAlchemy>=3
         return current_app.extensions['migrate'].db.engine
 
@@ -90,14 +90,17 @@ def run_migrations_online():
                 directives[:] = []
                 logger.info('No changes in schema detected.')
 
+    conf_args = current_app.extensions['migrate'].configure_args
+    if conf_args.get("process_revision_directives") is None:
+        conf_args["process_revision_directives"] = process_revision_directives
+
     connectable = get_engine()
 
     with connectable.connect() as connection:
         context.configure(
             connection=connection,
             target_metadata=get_metadata(),
-            process_revision_directives=process_revision_directives,
-            **current_app.extensions['migrate'].configure_args
+            **conf_args
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
When the database is created it will now automatically name things so future migrations work properly. 
Minor tweaks to `env.py`
Added `migrations/versions/0a43986f4f83_remove_selected_tabs_column_from_event.py` to the `.gitignore` so we can have different versions of it